### PR TITLE
Add support for twitch OAuth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Default options:
 * `options.ua` -> User agent sent to `Twitch.tv`
 * `options.apiVersion` -> API version used
 * `options.clientID` -> Client ID provided by `Twitch.tv`. Used for rate-limiting
+* `options.auth` -> OAuth token provided by `Twitch.tv`. Used for privileged requests ([doc here](https://dev.twitch.tv/docs/v5/guides/authentication/))
 
 `callback` is called with two parameters: `err` and `response`.
 
@@ -58,5 +59,12 @@ twitch("videos/top", {
 twitch("channels/44322889", {
   apiVersion: 5,
   clientID: "uo6dggojyb8d6soh92zknwmi5ej1q2"
+})
+
+// https://dev.twitch.tv/docs/v5/reference/users/#get-user
+twitch("user", {
+  apiVersion: 5,
+  clientID: "uo6dggojyb8d6soh92zknwmi5ej1q2",
+  auth: "cfabdegwdoklmawdzdo98xt2fo512y"
 })
 ```

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ module.exports = function getAPI(apiMethod, options, callback) {
 		"Client-ID": options.clientID || ""
 	}
 
+	if (typeof options.auth === "string"){
+		headers["Authorization"] = "OAuth " + options.auth;
+	}
+
 	request({
 		url: baseUrl + apiMethod,
 		headers: headers


### PR DESCRIPTION
Hello it's me ! (again)

I've added an option to pass an OAuth token via headers because some Twitch API endpoints require a token and passing it via query parameters is a potential security issue...

The Twitch documentation about that header is [located here](https://dev.twitch.tv/docs/v5/guides/authentication/#sending-access-tokens).
I've tested this in my project and it works :slightly_smiling_face: 